### PR TITLE
Use the new workflow.inputfile handling

### DIFF
--- a/rules/calling.smk
+++ b/rules/calling.smk
@@ -54,7 +54,6 @@ rule genotype_variants:
 
 rule merge_variants:
     input:
-        ref=get_fai(), # fai is needed to calculate aggregation over contigs below
         vcfs=lambda w: expand("genotyped/all.{contig}.vcf.gz", contig=get_contigs()),
     output:
         vcf="genotyped/all.vcf.gz"

--- a/rules/calling.smk
+++ b/rules/calling.smk
@@ -54,6 +54,8 @@ rule genotype_variants:
 
 rule merge_variants:
     input:
+        # Ensure that fai is present in the cloud before calling get_contigs().
+        fai=get_fai(),
         vcfs=lambda w: expand("genotyped/all.{contig}.vcf.gz", contig=get_contigs()),
     output:
         vcf="genotyped/all.vcf.gz"

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -33,8 +33,11 @@ def get_fai():
 
 # contigs in reference genome
 def get_contigs():
-    return pd.read_table(get_fai(),
-                         header=None, usecols=[0], squeeze=True, dtype=str)
+    # Open the .fai in a way that respects eventual --default-remote-provider settings
+    # for cloud execution.
+    with workflow.inputfile(get_fai()).open() as fai:
+        return pd.read_table(fai,
+                             header=None, usecols=[0], squeeze=True, dtype=str)
 
 def get_fastq(wildcards):
     """Get fastq files of given sample-unit."""


### PR DESCRIPTION
 For transparent .fai reading in the cloud.

xref: snakemake/snakemake#35