### PR TITLE
use peppy

### DIFF
--- a/pep_config.yaml
+++ b/pep_config.yaml
@@ -1,0 +1,5 @@
+metadata:
+  sample_table: samples.tsv
+  subsample_table: units.tsv
+
+snake_config: "config.yaml"

--- a/pep_config.yaml
+++ b/pep_config.yaml
@@ -1,3 +1,4 @@
+pep_version: 2.0.0
 sample_table: samples.tsv
 subsample_table: units.tsv
 snake_config: "config.yaml"

--- a/pep_config.yaml
+++ b/pep_config.yaml
@@ -1,5 +1,3 @@
-metadata:
-  sample_table: samples.tsv
-  subsample_table: units.tsv
-
+sample_table: samples.tsv
+subsample_table: units.tsv
 snake_config: "config.yaml"

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,4 +1,5 @@
 import pandas as pd
+from peppy import Project
 from snakemake.utils import validate
 from snakemake.utils import min_version
 
@@ -6,15 +7,17 @@ min_version("5.7.1")
 
 report: "../report/workflow.rst"
 
+p = Project(cfg="prjcfg.yaml", sample_table_index="sample",
+            subsample_table_index=["sample", "unit"])
+
 ###### Config file and sample sheets #####
-configfile: "config.yaml"
+configfile: p.config.snake_config
 validate(config, schema="../schemas/config.schema.yaml")
 
-samples = pd.read_table(config["samples"]).set_index("sample", drop=False)
+samples = p.sample_table
 validate(samples, schema="../schemas/samples.schema.yaml")
 
-units = pd.read_table(config["units"], dtype=str).set_index(["sample", "unit"], drop=False)
-units.index = units.index.set_levels([i.astype(str) for i in units.index.levels])  # enforce str in index
+units = p.subsample_table
 validate(units, schema="../schemas/units.schema.yaml")
 
 

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -7,7 +7,7 @@ min_version("5.7.1")
 
 report: "../report/workflow.rst"
 
-p = Project(cfg="prjcfg.yaml", sample_table_index="sample",
+p = Project(cfg="pep_config.yaml", sample_table_index="sample",
             subsample_table_index=["sample", "unit"])
 
 ###### Config file and sample sheets #####


### PR DESCRIPTION
@vreuter, @nsheff, @johanneskoester

This is a reiteration of #8, but with a re-written version of `peppy` that supports the config format revamp discussed in https://github.com/pepkit/peppy/issues/334
